### PR TITLE
Update to title, subtitle and some correction of spelling mistake

### DIFF
--- a/app/views/index.html
+++ b/app/views/index.html
@@ -13,8 +13,8 @@
         <div class="nhsuk-grid-row">
           <div class="nhsuk-grid-column-two-thirds">
             <div class="nhsuk-hero__wrapper app-hero__wrapper" style="padding-top: 40px;">
-              <h1 class="nhsuk-u-margin-bottom-4">Building digital services for the NHS Wales. </h1>
-              <p class="nhsuk-body-l nhsuk-u-margin-bottom-1">NHS Wales has adopted the NHS Service Manual and Design System to design and build digital services in Wales. <br>The NHS Wales Design System incorporates additional design requirements specific to NHS Wales to design and build consistent and usable digital services that put Welsh people first.</p>
+              <h1 class="nhsuk-u-margin-bottom-4">Design and build accessible digital services for NHS Wales. </h1>
+              <p class="nhsuk-body-l nhsuk-u-margin-bottom-1">Use the NHS Wales Design System to create consistent, user-centred digital services. It follows the NHS service manual and has additional components, patterns, styles and templates developed for NHS Wales.</p>
             </div>
           </div>
           <!-- WHAT'S NEW
@@ -58,7 +58,7 @@
                   <br>
                   <a href="https://service-manual.nhs.uk/content" target="blank" style="color: #005eb8;">Content guide</a> 
                   <br>
-                  <a href="https://service-manual.nhs.uk/accessibility" target="blank" style="color: #005eb8;">Accesibility</a> 
+                  <a href="https://service-manual.nhs.uk/accessibility" target="blank" style="color: #005eb8;">Accessibility</a> 
                   <br>
                   <a href="https://service-manual.nhs.uk/design-system/design-principles" target="blank" style="color: #005eb8;">Design principles</a>
                   <br>
@@ -139,7 +139,7 @@
           <div class="nhsuk-grid-column-full">
             <hr class="nhsuk-u-margin-top-2 nhsuk-u-margin-bottom-6">
             <h2>Support</h2>
-            <p style="padding-bottom: 20px;">The manual is maintained by the <a href="design-system-team" style="color: #005eb8;">design system team at NHS Wales</a>. <br>If you've got a question or want to feedback, you can <a href="get-in-touch" style="color: #005eb8;">get in touch</a>.</p>
+            <p style="padding-bottom: 20px;">The manual is maintained by the <a href="design-system-team" style="color: #005eb8;">design system team at NHS Wales</a>. <br>If you've got a question or want to give feedback, you can <a href="get-in-touch" style="color: #005eb8;">get in touch</a>.</p>
           </div>
         </div>
 


### PR DESCRIPTION
Update to title, subtitle and some correction of spelling mistake

## Description
* Changed the title to include references to accessibility and removed 'the' from 'the NHS Wales'
* Rewrote the subtitle to make it clear that we're adapting the NHS design system, but with additional NHS Wales-specific elements
* Changed a spelling mistake (accesibility -> accessibility) 


## Motivation and Context
* A first pass at the main landing page for the new NHS Wales Design System. To be further iterated.


