### PR TITLE
Major content update

### DIFF
--- a/app/views/components-body.html
+++ b/app/views/components-body.html
@@ -34,11 +34,11 @@
             <span class="nhsuk-u-visually-hidden"> - </span>
           </span>
 
-          <h1 class="nhsuk-heading-xl">Body <span style="vertical-align: middle;"><strong class="nhsuk-tag">Work in progress</strong></span></h1>
+          <h1 class="nhsuk-heading-xl">Body <span style="vertical-align: middle;"><strong class="nhsuk-tag">In progress</strong></span></h1>
 
           <div class="nhsuk-inset-text">
             <span class="nhsuk-u-visually-hidden">Information: </span>
-            <p>We are working on this page. <br>The content will be released by August 29 2025.</p>
+            <p>We're working on body components for NHS Wales. <br>We aim to publish these components in August 2025.</p>
           </div>
 
           <p>This page lists and describes different body components you can use to design digital services.</p>
@@ -58,3 +58,4 @@
 </body>
 
 </html>
+

--- a/app/views/cookie-policy.html
+++ b/app/views/cookie-policy.html
@@ -49,28 +49,32 @@
 
             <h2>What are cookies?</h2>
 
-            <p>Cookies are files saved on your phone, tablet or computer when you visit a website.</p>
+            <p>Cookies are small files saved on your phone, tablet, or computer by websites that you visit. They are widely used to make websites work, or work more efficiently, as well as to provide information to the owners of the site.</p>
+            
+            <p>The information stored in cookies is used to make websites work or contains things about how you use the website. For example, that you have acknowledged a pop-up or the pages you visit.
+            
+            <p>Cookies are not viruses or computer programs. They are very small text files, so they do not take up much space on your computer or mobile device by websites that you visit. </p>
+            
+            <p>This statement refers to ‘cookies’ but covers similar browser storage technologies, such as HTML local storage. Our cookies do not contain any personal information about you and do not hold any information about which sites you visited before you came here.  </p>
 
-            <p>They store information about how you use the website, such as the pages you visit.</p>
-
-            <p>Cookies are not viruses or computer programs. They are very small so do not take up much space.</p>
 
             <h2>How we use cookies</h2>
 
             <p>We only use cookies to:</p>
 
             <ul>
-              <li>make our website work</li>
+              <li>make our website work, for example by keeping it secure</li>
               <li>measure how you use our website, such as which links you click on (analytics cookies), if you give us permission</li>
             </ul>
 
-            <p>We do not use any other cookies, for example, cookies that remember your settings or cookies that help with health campaigns.</p>
+           <p>Each cookie listed shows the cookie name, type, duration, and purpose.</p>
+           
+            <p>We use cookies only for the purpose described.</p>
 
-            <p>We sometimes use tools on other organisations' websites to collect data or to ask for feedback. These tools set their own cookies. </p>
-
-            <h2>Cookies that make our website work</h2>
-
-            <p>We use cookies to keep our website secure and fast.</p>
+          <h2>Essential cookies</h2>
+           <p>These essential, or ‘strictly necessary’, cookies enable basic functions like page navigation and access to secure areas of the website.</p>
+         
+            <p>Our website and services cannot function properly without these cookies, so we do not provide a way to manage them. They can only be blocked or deleted by changing your browser preferences, as described in the Managing Cookies section in this statement.</p>
 
           </div>
 
@@ -78,7 +82,7 @@
 
             <summary class="nhsuk-details__summary">
               <span class="nhsuk-details__summary-text">
-                List of cookies that make our website work
+                List of essential cookies
               </span>
             </summary>
 
@@ -88,15 +92,105 @@
                 <thead class="nhsuk-table__head" role="rowgroup">
                   <tr class="nhsuk-table__row" role="row">
                     <th class="nhsuk-table__header" role="columnheader" scope="col">Cookie name</th>
+                    <th class="nhsuk-table__header" role="columnheader" scope="col">Service</th>
                     <th class="nhsuk-table__header" role="columnheader" scope="col">Purpose</th>
                     <th class="nhsuk-table__header" role="columnheader" scope="col">Expiry</th>
                   </tr>
-                </thead>
+                </thead>    
                 <tbody class="nhsuk-table__body">
                   <tr class="nhsuk-table__row" role="row">
-                    <td class="nhsuk-table__cell" role="cell"><span class="nhsuk-table-responsive__heading" aria-hidden="true">Cookie name </span>nhsuk-cookie-consent</td>
-                    <td class="nhsuk-table__cell" role="cell"><span class="nhsuk-table-responsive__heading" aria-hidden="true">Purpose </span>Remembers if you used our cookies banner</td>
-                    <td class="nhsuk-table__cell" role="cell"><span class="nhsuk-table-responsive__heading" aria-hidden="true">Expiry </span>When you close the browser (if you do not use the banner) or 1 year (if you use the banner)</td>
+                    <td class="nhsuk-table__cell" role="cell"><span class="nhsuk-table-responsive__heading" aria-hidden="true">Cookie name </span>cfide</td>
+                    <td class="nhsuk-table__cell" role="cell"><span class="nhsuk-table-responsive__heading" aria-hidden="true">Service </span>Mura</td>
+                    <td class="nhsuk-table__cell" role="cell"><span class="nhsuk-table-responsive__heading" aria-hidden="true">Purpose </span>Identifying the code of the client's current session. It allows the server to identify the client from whom it receives the calls.</td>
+                    <td class="nhsuk-table__cell" role="cell"><span class="nhsuk-table-responsive__heading" aria-hidden="true">Expiry </span>1 year 1 month 6 days</td>
+                  </tr>
+                </tbody> 
+                 <tbody class="nhsuk-table__body">
+                  <tr class="nhsuk-table__row" role="row">
+                    <td class="nhsuk-table__cell" role="cell"><span class="nhsuk-table-responsive__heading" aria-hidden="true">Cookie name </span>cftoken</td>
+                    <td class="nhsuk-table__cell" role="cell"><span class="nhsuk-table-responsive__heading" aria-hidden="true">Service </span>Mura</td>
+                    <td class="nhsuk-table__cell" role="cell"><span class="nhsuk-table-responsive__heading" aria-hidden="true">Purpose </span>To keep track of user sessions on the site and identify your user session.</td>
+                    <td class="nhsuk-table__cell" role="cell"><span class="nhsuk-table-responsive__heading" aria-hidden="true">Expiry </span>1 year 1 month 6 days</td>
+                  </tr>
+                </tbody> 
+                <tbody class="nhsuk-table__body">
+                  <tr class="nhsuk-table__row" role="row">
+                    <td class="nhsuk-table__cell" role="cell"><span class="nhsuk-table-responsive__heading" aria-hidden="true">Cookie name </span>MuraCMSAffinity</td>
+                    <td class="nhsuk-table__cell" role="cell"><span class="nhsuk-table-responsive__heading" aria-hidden="true">Service </span>Mura</td>
+                    <td class="nhsuk-table__cell" role="cell"><span class="nhsuk-table-responsive__heading" aria-hidden="true">Purpose </span>Manages sticky sessions in a load-balanced environment, to keep a user's session tied to a single server.</td>
+                    <td class="nhsuk-table__cell" role="cell"><span class="nhsuk-table-responsive__heading" aria-hidden="true">Expiry </span>End of session</td>
+                  </tr>
+                </tbody> 
+                 <tbody class="nhsuk-table__body">
+                  <tr class="nhsuk-table__row" role="row">
+                    <td class="nhsuk-table__cell" role="cell"><span class="nhsuk-table-responsive__heading" aria-hidden="true">Cookie name </span>MuraCMSAffinityCORS</td>
+                    <td class="nhsuk-table__cell" role="cell"><span class="nhsuk-table-responsive__heading" aria-hidden="true">Service </span>Mura</td>
+                    <td class="nhsuk-table__cell" role="cell"><span class="nhsuk-table-responsive__heading" aria-hidden="true">Purpose </span>Manages sticky sessions in a load-balanced environment, to keep a user's session tied to a single server.</td>
+                    <td class="nhsuk-table__cell" role="cell"><span class="nhsuk-table-responsive__heading" aria-hidden="true">Expiry </span>End of session</td>
+                  </tr>
+                </tbody>
+                <tbody class="nhsuk-table__body">
+                  <tr class="nhsuk-table__row" role="row">
+                    <td class="nhsuk-table__cell" role="cell"><span class="nhsuk-table-responsive__heading" aria-hidden="true">Cookie name </span>MXP_TRACKINGID</td>
+                    <td class="nhsuk-table__cell" role="cell"><span class="nhsuk-table-responsive__heading" aria-hidden="true">Service </span>Mura</td>
+                    <td class="nhsuk-table__cell" role="cell"><span class="nhsuk-table-responsive__heading" aria-hidden="true">Purpose </span>This relates to the suite of features with MXP, which gives the ability for users to have a personalized experience while on that mura site, based on selections either made by the user or the site. This cookie enables the site to persist an experience unique to that decision. If you are not leveraging MXP, this cookie serves no purpose.</td>
+                    <td class="nhsuk-table__cell" role="cell"><span class="nhsuk-table-responsive__heading" aria-hidden="true">Expiry </span>1 year 1 month 6 days</td>
+                  </tr>
+                </tbody>
+                 <tbody class="nhsuk-table__body">
+                  <tr class="nhsuk-table__row" role="row">
+                    <td class="nhsuk-table__cell" role="cell"><span class="nhsuk-table-responsive__heading" aria-hidden="true">Cookie name </span>MURA_UPC</td>
+                    <td class="nhsuk-table__cell" role="cell"><span class="nhsuk-table-responsive__heading" aria-hidden="true">Service </span>Mura</td>
+                    <td class="nhsuk-table__cell" role="cell"><span class="nhsuk-table-responsive__heading" aria-hidden="true">Purpose </span>This is the output cache, it allows for requests to use the proxy cache - our goal is to put a proxy in front of each API call to Mura, this tells whether or not it should be used or not.</td>
+                    <td class="nhsuk-table__cell" role="cell"><span class="nhsuk-table-responsive__heading" aria-hidden="true">Expiry </span>1 year 1 month 6 days</td>
+                  </tr>
+                </tbody>
+                <tbody class="nhsuk-table__body">
+                  <tr class="nhsuk-table__row" role="row">
+                    <td class="nhsuk-table__cell" role="cell"><span class="nhsuk-table-responsive__heading" aria-hidden="true">Cookie name </span>rb</td>
+                    <td class="nhsuk-table__cell" role="cell"><span class="nhsuk-table-responsive__heading" aria-hidden="true">Service </span>Mura</td>
+                    <td class="nhsuk-table__cell" role="cell"><span class="nhsuk-table-responsive__heading" aria-hidden="true">Purpose </span>Is a resource bundle cookie that should only affect when you are logged into admin.</td>
+                    <td class="nhsuk-table__cell" role="cell"><span class="nhsuk-table-responsive__heading" aria-hidden="true">Expiry </span>1 year 1 month 6 days</td>
+                  </tr>
+                </tbody>
+                 <tbody class="nhsuk-table__body">
+                  <tr class="nhsuk-table__row" role="row">
+                    <td class="nhsuk-table__cell" role="cell"><span class="nhsuk-table-responsive__heading" aria-hidden="true">Cookie name </span>FETDISPLAY</td>
+                    <td class="nhsuk-table__cell" role="cell"><span class="nhsuk-table-responsive__heading" aria-hidden="true">Service </span>Mura</td>
+                    <td class="nhsuk-table__cell" role="cell"><span class="nhsuk-table-responsive__heading" aria-hidden="true">Purpose </span>Is a toolbar on the front end, where hitting the logo does or doesn't show it. Again, this only affects you when you are logged into admin.</td>
+                    <td class="nhsuk-table__cell" role="cell"><span class="nhsuk-table-responsive__heading" aria-hidden="true">Expiry </span>1 year 1 month 6 days</td>
+                  </tr>
+                </tbody>
+                <tbody class="nhsuk-table__body">
+                  <tr class="nhsuk-table__row" role="row">
+                    <td class="nhsuk-table__cell" role="cell"><span class="nhsuk-table-responsive__heading" aria-hidden="true">Cookie name </span>MURA_OSC</td>
+                    <td class="nhsuk-table__cell" role="cell"><span class="nhsuk-table-responsive__heading" aria-hidden="true">Service </span>Mura</td>
+                    <td class="nhsuk-table__cell" role="cell"><span class="nhsuk-table-responsive__heading" aria-hidden="true">Purpose </span>Allows the user to cache or not cache. This uniquely sets when you actually do use the cache, so the cache is relevant.</td>
+                    <td class="nhsuk-table__cell" role="cell"><span class="nhsuk-table-responsive__heading" aria-hidden="true">Expiry </span>1 year 1 month 6 days</td>
+                  </tr>
+                </tbody>                
+                <tbody class="nhsuk-table__body">
+                  <tr class="nhsuk-table__row" role="row">
+                    <td class="nhsuk-table__cell" role="cell"><span class="nhsuk-table-responsive__heading" aria-hidden="true">Cookie name </span>infobanner</td>
+                    <td class="nhsuk-table__cell" role="cell"><span class="nhsuk-table-responsive__heading" aria-hidden="true">Service </span>Mura</td>
+                    <td class="nhsuk-table__cell" role="cell"><span class="nhsuk-table-responsive__heading" aria-hidden="true">Purpose </span>Information banner is a module that may be added to the site, when dismissed a cookie is created to indicate it should not appear again for the duration of the session. </td>
+                    <td class="nhsuk-table__cell" role="cell"><span class="nhsuk-table-responsive__heading" aria-hidden="true">Expiry </span>End of session</td>
+                  </tr>
+                </tbody>                
+                <tbody class="nhsuk-table__body">
+                  <tr class="nhsuk-table__row" role="row">
+                    <td class="nhsuk-table__cell" role="cell"><span class="nhsuk-table-responsive__heading" aria-hidden="true">Cookie name </span>_rspkrLoadCore</td>
+                    <td class="nhsuk-table__cell" role="cell"><span class="nhsuk-table-responsive__heading" aria-hidden="true">Service </span>Mura</td>
+                    <td class="nhsuk-table__cell" role="cell"><span class="nhsuk-table-responsive__heading" aria-hidden="true">Purpose </span>Set after the service has been activated, for example when you have interacted with the player. An initiation cookie that determines whether or not to load the scripts on the page load.</td>
+                    <td class="nhsuk-table__cell" role="cell"><span class="nhsuk-table-responsive__heading" aria-hidden="true">Expiry </span>End of session</td>
+                  </tr>
+                </tbody>                
+                <tbody class="nhsuk-table__body">
+                  <tr class="nhsuk-table__row" role="row">
+                    <td class="nhsuk-table__cell" role="cell"><span class="nhsuk-table-responsive__heading" aria-hidden="true">Cookie name </span>ReadSpeakerSettings</td>
+                    <td class="nhsuk-table__cell" role="cell"><span class="nhsuk-table-responsive__heading" aria-hidden="true">Service </span>ReadSpeaker</td>
+                    <td class="nhsuk-table__cell" role="cell"><span class="nhsuk-table-responsive__heading" aria-hidden="true">Purpose </span>Set if you change a setting in the settings menu.</td>
+                    <td class="nhsuk-table__cell" role="cell"><span class="nhsuk-table-responsive__heading" aria-hidden="true">Expiry </span>4 days</td>
                   </tr>
                 </tbody>
               </table>
@@ -106,107 +200,38 @@
 
           <div class="nhsuk-u-reading-width">
 
-            <h2>Cookies that measure website use</h2>
+            <h2>Managing cookies</h2>
 
-            <p>We also like to use analytics cookies. These cookies store anonymous information about how you use our website, such as which pages you visit or what you click on.</p>
+          <p>Alternatively, most web browsers allow some control of most cookies through the browser settings. To find out more about cookies, including how to see what cookies have been set, visit <a href="www.aboutcookies.org">www.aboutcookies.org</a> or <a href="www.allaboutcookies.org">www.allaboutcookies.org</a>, or use the "Help" function within your browser.</p>
+          
+            <p>Find out how to manage cookies on popular browsers:</p>
+            <ul>
+              <li><a href="https://support.google.com/accounts/answer/61416?" target="_blank">Google Chrome</a></li>
+              <li><a href="https://privacy.microsoft.com/en-us/windows-10-microsoft-edge-and-privacy" target="_blank">Microsoft Edge</a></li>
+              <li><a href="https://support.mozilla.org/en-US/kb/enable-and-disable-cookies-website-preferences" target="_blank">Mozilla Firefox</a></li>
+              <li><a href="https://support.microsoft.com/en-gb/help/17442/windows-internet-explorer-delete-manage-cookies" target="_blank">Microsoft Internet Explorer</a></li>
+              <li><a href="https://www.opera.com/help/tutorials/security/privacy/" target="_blank">Opera</a></li>
+              <li><a href="https://support.apple.com/en-gb/safari" target="_blank">Apple Safari</a></li>
+            </ul>
+            <p>To find information relating to other browsers, visit the browser developer's website.</p>
 
           </div>
 
-          <details class="nhsuk-details">
-
-            <summary class="nhsuk-details__summary">
-              <span class="nhsuk-details__summary-text">
-                List of cookies that measure website use
-              </span>
-            </summary>
-
-            <div class="nhsuk-details__text">
-              <table class="nhsuk-table nhsuk-table-responsive">
-                <caption class="nhsuk-table__caption nhsuk-u-visually-hidden">Cookie names and purposes</caption>
-                <thead class="nhsuk-table__head" role="rowgroup">
-                  <tr class="nhsuk-table__row" role="row">
-                    <th class="nhsuk-table__header" role="columnheader" scope="col">Cookie name</th>
-                    <th class="nhsuk-table__header" role="columnheader" scope="col">Purpose</th>
-                    <th class="nhsuk-table__header" role="columnheader" scope="col">Expiry</th>
-                  </tr>
-                </thead>
-                <tbody class="nhsuk-table__body">
-                  <tr class="nhsuk-table__row" role="row">
-                    <td class="nhsuk-table__cell" role="cell"><span class="nhsuk-table-responsive__heading" aria-hidden="true">Cookie name </span>AMCV_#</td>
-                    <td class="nhsuk-table__cell" role="cell"><span class="nhsuk-table-responsive__heading" aria-hidden="true">Purpose </span>Used by Adobe Analytics. Tells us if you've used our site before.</td>
-                    <td class="nhsuk-table__cell" role="cell"><span class="nhsuk-table-responsive__heading" aria-hidden="true">Expiry </span>2 years</td>
-                  </tr>
-                  <tr class="nhsuk-table__row" role="row">
-                    <td class="nhsuk-table__cell" role="cell"><span class="nhsuk-table-responsive__heading" aria-hidden="true">Cookie name </span>AMCVS_#AdobeOrg</td>
-                    <td class="nhsuk-table__cell" role="cell"><span class="nhsuk-table-responsive__heading" aria-hidden="true">Purpose </span>Used by Adobe Analytics. Tells us how you use our site.</td>
-                    <td class="nhsuk-table__cell" role="cell"><span class="nhsuk-table-responsive__heading" aria-hidden="true">Expiry </span>When you close the browser</td>
-                  </tr>
-                  <tr class="nhsuk-table__row" role="row">
-                    <td class="nhsuk-table__cell" role="cell"><span class="nhsuk-table-responsive__heading" aria-hidden="true">Cookie name </span><span class="nhsuk-table__cell--break-all">com.adobe.reactor.dataElementCookiesMigrated</span></td>
-                    <td class="nhsuk-table__cell" role="cell"><span class="nhsuk-table-responsive__heading" aria-hidden="true">Purpose </span>Used by Adobe Analytics. Includes data elements set to capture usage of our website.</td>
-                    <td class="nhsuk-table__cell" role="cell"><span class="nhsuk-table-responsive__heading" aria-hidden="true">Expiry </span>No expiry</td>
-                  </tr>
-                  <tr class="nhsuk-table__row" role="row">
-                    <td class="nhsuk-table__cell" role="cell"><span class="nhsuk-table-responsive__heading" aria-hidden="true">Cookie name </span>demdex</td>
-                    <td class="nhsuk-table__cell" role="cell"><span class="nhsuk-table-responsive__heading" aria-hidden="true">Purpose </span>Used by Adobe Analytics. Allows cross-domain analytics of NHS properties.</td>
-                    <td class="nhsuk-table__cell" role="cell"><span class="nhsuk-table-responsive__heading" aria-hidden="true">Expiry </span>180 days</td>
-                  </tr>
-                  <tr class="nhsuk-table__row" role="row">
-                    <td class="nhsuk-table__cell" role="cell"><span class="nhsuk-table-responsive__heading" aria-hidden="true">Cookie name </span>s_cc</td>
-                    <td class="nhsuk-table__cell" role="cell"><span class="nhsuk-table-responsive__heading" aria-hidden="true">Purpose </span>Used by Adobe Analytics. Checks if cookies work in your web browser.</td>
-                    <td class="nhsuk-table__cell" role="cell"><span class="nhsuk-table-responsive__heading" aria-hidden="true">Expiry </span>When you close the browser</td>
-                  </tr>
-                  <tr class="nhsuk-table__row" role="row">
-                    <td class="nhsuk-table__cell" role="cell"><span class="nhsuk-table-responsive__heading" aria-hidden="true">Cookie name </span>s_getNewRepeat</td>
-                    <td class="nhsuk-table__cell" role="cell"><span class="nhsuk-table-responsive__heading" aria-hidden="true">Purpose </span>Used by Adobe Analytics. Tells us if you've used our website before.</td>
-                    <td class="nhsuk-table__cell" role="cell"><span class="nhsuk-table-responsive__heading" aria-hidden="true">Expiry </span>30 days</td>
-                  </tr>
-                  <tr class="nhsuk-table__row" role="row">
-                    <td class="nhsuk-table__cell" role="cell"><span class="nhsuk-table-responsive__heading" aria-hidden="true">Cookie name </span>s_ppn</td>
-                    <td class="nhsuk-table__cell" role="cell"><span class="nhsuk-table-responsive__heading" aria-hidden="true">Purpose </span>Used by Adobe Analytics. Tells us how you use our website by reading the previous page you visited.</td>
-                    <td class="nhsuk-table__cell" role="cell"><span class="nhsuk-table-responsive__heading" aria-hidden="true">Expiry </span>1 day</td>
-                  </tr>
-                  <tr class="nhsuk-table__row" role="row">
-                    <td class="nhsuk-table__cell" role="cell"><span class="nhsuk-table-responsive__heading" aria-hidden="true">Cookie name </span>s_sq</td>
-                    <td class="nhsuk-table__cell" role="cell"><span class="nhsuk-table-responsive__heading" aria-hidden="true">Purpose </span>Used by Adobe Analytics. Remembers the last link you clicked on.</td>
-                    <td class="nhsuk-table__cell" role="cell"><span class="nhsuk-table-responsive__heading" aria-hidden="true">Expiry </span>When you close the browser</td>
-                  </tr>
-                </tbody>
-              </table>
-            </div>
-
-          </details>
 
           <div class="nhsuk-u-reading-width">
+            <h2>Further information</h2>
+            <p><a href="/get-in-touch">Get in touch</a> if you have any questions about our use of cookies or other technologies.</p>
+            
 
-            <p>We'll only use these cookies if you say it's OK. We'll use a cookie to save your settings.</p>
-
-            <h3>Tell us if we can use analytics cookies</h3>
-
-            <fieldset class="nhsuk-fieldset" id="cookie-statistics-form" aria-describedby="cookie-statistics">
-              <div class="nhsuk-radios nhsuk-radios--inline nhsuk-u-margin-bottom-6">
-                <div class="nhsuk-radios__item">
-                  <input class="nhsuk-radios__input" id="input-statistics-1" name="input-statistics" type="radio" value="on">
-                  <label class="nhsuk-label nhsuk-radios__label" for="input-statistics-1">
-                  Use cookies to measure my website use
-                  </label>
-                </div>
-                <div class="nhsuk-radios__item">
-                  <input class="nhsuk-radios__input" id="input-statistics-2" name="input-statistics" type="radio" value="yes">
-                  <label class="nhsuk-label nhsuk-radios__label" for="input-statistics-2">
-                  Do not use cookies to measure my website use
-                  </label>
-                </div>
-              </div>
-            </fieldset>
-
-            <a href="/cookie-confirmation" onclick="changeConsent();" type="submit" class="nhsuk-button nhsuk-u-margin-bottom-0">
-              Save my cookie settings
-            </a>
+          </div>
+          <div class="nhsuk-u-reading-width">
+            <h2>Statement updates</h2>
+            <p>We may update this cookie statement from time to time to reflect changes to the cookies we use or for other operational, legal, or regulatory reasons. You will be prompted to re-consent to the cookies when we update this statement.</p>
+            
 
           </div>
 
-          <p class="nhsuk-body-s nhsuk-u-secondary-text-color nhsuk-u-margin-top-7 nhsuk-u-margin-bottom-0">Updated: April 2025</p>
+          <p class="nhsuk-body-s nhsuk-u-secondary-text-color nhsuk-u-margin-top-7 nhsuk-u-margin-bottom-0">Updated: July 2025</p>
 
         </div>
         

--- a/app/views/design-system-team.html
+++ b/app/views/design-system-team.html
@@ -45,18 +45,19 @@
 
           <h1 class="nhsuk-heading-xl">Design system team</h1>      
 
-          <p class="nhsuk-lede-text app-lede-text">The design system team at NHS Wales maintains the design system.</p>
+          <p class="nhsuk-lede-text app-lede-text">The user-centred design team at Digital Health and Care Wales maintains the NHS Wales design system.</p>
+          <p>We work with colleagues across NHS Wales to research and develop components, patterns and templates based on evidence.</p>
 
           <p>If you want to contact the team, you can <a href="/get-in-touch" style="color: #005eb8;">get in touch via email</a>.</p>
 
           <ul>
-            <li>Rachel  Meese – head of UCD</li>
+            <li>Rachel Meese – Head of User-Centred Design</li>
             <li>Ramon Delgado – Senior Interaction Designer</li>
-            <li>Sarah-ann Davies – Graphic designer</li>
+            <li>Sarah-ann Davies – Senior Graphic Designer</li>
             <li>Emma Lynham – Senior Content Designer</li>
           </ul>
 
-          <p class="nhsuk-body-s nhsuk-u-secondary-text-color nhsuk-u-margin-top-6 nhsuk-u-margin-bottom-0">Updated: February 2025</p>
+          <p class="nhsuk-body-s nhsuk-u-secondary-text-color nhsuk-u-margin-top-6 nhsuk-u-margin-bottom-0">Updated: July 2025</p>
 
         </div>
 

--- a/app/views/get-in-touch.html
+++ b/app/views/get-in-touch.html
@@ -45,11 +45,11 @@
 
           <h1 class="nhsuk-heading-xl">Get in touch</h1>      
 
-          <p class="nhsuk-lede-text app-lede-text">If you’ve got a question, idea or suggestion, get in touch with the service manual team.</p>
+          <p class="nhsuk-lede-text app-lede-text">If you’ve got a question, idea or suggestion, get in touch with the user-centred design team.</p>
 
-          <p>Email the service manual team on <a href="mailto:design-system@wales.nhs.uk" style="color: #005eb8;">design-system@wales.nhs.uk</a>.</p>
+          <p>Email the team on <a href="mailto:design-system@wales.nhs.uk" style="color: #005eb8;">design-system@wales.nhs.uk</a>.</p>
 
-          <p class="nhsuk-body-s nhsuk-u-secondary-text-color nhsuk-u-margin-top-6 nhsuk-u-margin-bottom-0">Updated: September 2024</p>
+          <p class="nhsuk-body-s nhsuk-u-secondary-text-color nhsuk-u-margin-top-6 nhsuk-u-margin-bottom-0">Updated: July 2025</p>
 
         </div>
 

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -81,7 +81,7 @@
                 <p class="nhsuk-card__description">
                   <a href="components-header" style="color: #005eb8;">Header</a>
                   <br>
-                  <a href="components-body" style="color: #005eb8;">Body</a> <strong class="nhsuk-tag-new">WIP</strong>
+                  <a href="components-body" style="color: #005eb8;">Body</a> <strong class="nhsuk-tag-new">In progress</strong>
                   <br>
                   <a href="components-footer" style="color: #005eb8;">Footer</a>
                 </p>
@@ -93,11 +93,11 @@
               <div class="nhsuk-card__content">
                 <h3 class="nhsuk-card__heading"><a href="patterns" style="color: #005eb8;">Patterns</a></h3>
                 <p class="nhsuk-card__description">
-                  <a href="patterns-tasks" style="color: #005eb8;">Task patterns</a> <strong class="nhsuk-tag-new">WIP</strong>
+                  <a href="patterns-tasks" style="color: #005eb8;">Task patterns</a> <strong class="nhsuk-tag-new">In progress</strong>
                   <br>
-                  <a href="patterns-pages" style="color: #005eb8;">Page patterns</a> <strong class="nhsuk-tag-new">WIP</strong>
+                  <a href="patterns-pages" style="color: #005eb8;">Page patterns</a> <strong class="nhsuk-tag-new">In progress</strong>
                   <br>
-                  <a href="patterns-services" style="color: #005eb8;">Service patterns</a> <strong class="nhsuk-tag-new">WIP</strong>
+                  <a href="patterns-services" style="color: #005eb8;">Service patterns</a> <strong class="nhsuk-tag-new">In progress</strong>
                 </p>
               </div>
             </div>
@@ -123,11 +123,11 @@
                 <p class="nhsuk-card__description">
                   <a href="templates-websites" style="color: #005eb8;">Websites</a>
                   <br>
-                  <a href="templates-applications" style="color: #005eb8;">Applications</a> <strong class="nhsuk-tag-new">WIP</strong>
+                  <a href="templates-applications" style="color: #005eb8;">Applications</a> <strong class="nhsuk-tag-new">In progress</strong>
                   <br>
-                  <a href="templates-extranets" style="color: #005eb8;">Extranets</a> <strong class="nhsuk-tag-new">WIP</strong>
+                  <a href="templates-extranets" style="color: #005eb8;">Extranets</a> <strong class="nhsuk-tag-new">In progress</strong>
                   <br>
-                  <a href="templates-intranets" style="color: #005eb8;">Intranets</a> <strong class="nhsuk-tag-new">WIP</strong>
+                  <a href="templates-intranets" style="color: #005eb8;">Intranets</a> <strong class="nhsuk-tag-new">In progress</strong>
                 </p>
               </div>
             </div>

--- a/app/views/patterns-pages.html
+++ b/app/views/patterns-pages.html
@@ -34,11 +34,11 @@
             <span class="nhsuk-u-visually-hidden"> - </span>
           </span>
 
-          <h1 class="nhsuk-heading-xl">Page patterns <span style="vertical-align: middle;"><strong class="nhsuk-tag">Work in progress</strong></span></h1>
+          <h1 class="nhsuk-heading-xl">Page patterns <span style="vertical-align: middle;"><strong class="nhsuk-tag">In progress</strong></span></h1>
 
           <div class="nhsuk-inset-text">
             <span class="nhsuk-u-visually-hidden">Information: </span>
-            <p>We are working on this page. <br>The content will be released by August 29 2025.</p>
+           <p>We're working on page patterns for NHS Wales. <br>We aim to publish these patterns in August 2025.</p>
           </div>
 
           <p>This page lists and describes different page patterns you can use to design digital services.</p>

--- a/app/views/patterns-services.html
+++ b/app/views/patterns-services.html
@@ -34,11 +34,11 @@
             <span class="nhsuk-u-visually-hidden"> - </span>
           </span>
 
-          <h1 class="nhsuk-heading-xl">Service patterns <span style="vertical-align: middle;"><strong class="nhsuk-tag">Work in progress</strong></span></h1>
+          <h1 class="nhsuk-heading-xl">Service patterns <span style="vertical-align: middle;"><strong class="nhsuk-tag">In progress</strong></span></h1>
 
           <div class="nhsuk-inset-text">
             <span class="nhsuk-u-visually-hidden">Information: </span>
-            <p>We are working on this page. <br>The content will be released by August 29 2025.</p>
+            <p>We're working on service patterns for NHS Wales. <br>We aim to publish these patterns in August 2025.</p>
           </div>
 
           <p>This page lists and describes different service patterns you can use to design digital services.</p>

--- a/app/views/patterns-tasks.html
+++ b/app/views/patterns-tasks.html
@@ -34,11 +34,11 @@
             <span class="nhsuk-u-visually-hidden"> - </span>
           </span>
 
-          <h1 class="nhsuk-heading-xl">Task patterns <span style="vertical-align: middle;"><strong class="nhsuk-tag">Work in progress</strong></span></h1>
+          <h1 class="nhsuk-heading-xl">Task patterns <span style="vertical-align: middle;"><strong class="nhsuk-tag">In progress</strong></span></h1>
 
           <div class="nhsuk-inset-text">
             <span class="nhsuk-u-visually-hidden">Information: </span>
-            <p>We are working on this page. <br>The content will be released by August 29 2025.</p>
+            <p>We're working on task patterns for NHS Wales. <br>We aim to publish these patterns in August 2025.</p>
           </div>
 
           <p>This page lists and describes different task patterns you can use to design digital services.</p>

--- a/app/views/templates-applications.html
+++ b/app/views/templates-applications.html
@@ -34,11 +34,11 @@
             <span class="nhsuk-u-visually-hidden"> - </span>
           </span>
 
-          <h1 class="nhsuk-heading-xl">Applications <span style="vertical-align: middle;"><strong class="nhsuk-tag">Work in progress</strong></span></h1>
+          <h1 class="nhsuk-heading-xl">Applications <span style="vertical-align: middle;"><strong class="nhsuk-tag">In progress</strong></span></h1>
 
           <div class="nhsuk-inset-text">
             <span class="nhsuk-u-visually-hidden">Information: </span>
-            <p>We are working on this page. <br>The content will be released by August 29 2025.</p>
+             <p>We're working on application templates for NHS Wales. <br>We aim to publish these templates in August 2025.</p>
           </div>
 
           <p>This page lists and describes different templates you can use to design applications.</p>

--- a/app/views/templates-extranets.html
+++ b/app/views/templates-extranets.html
@@ -34,11 +34,11 @@
             <span class="nhsuk-u-visually-hidden"> - </span>
           </span>
 
-          <h1 class="nhsuk-heading-xl">Extranets <span style="vertical-align: middle;"><strong class="nhsuk-tag">Work in progress</strong></span></h1>
+          <h1 class="nhsuk-heading-xl">Extranets <span style="vertical-align: middle;"><strong class="nhsuk-tag">In progress</strong></span></h1>
 
           <div class="nhsuk-inset-text">
             <span class="nhsuk-u-visually-hidden">Information: </span>
-            <p>We are working on this page. <br>The content will be released by August 29 2025.</p>
+             <p>We're working on extranet templates for NHS Wales. <br>We aim to publish these templates in August 2025.</p>
           </div>
 
           <p>This page lists and describes different templates you can use to design extranets.</p>

--- a/app/views/templates-intranets.html
+++ b/app/views/templates-intranets.html
@@ -34,14 +34,14 @@
             <span class="nhsuk-u-visually-hidden"> - </span>
           </span>
 
-          <h1 class="nhsuk-heading-xl">Intranets <span style="vertical-align: middle;"><strong class="nhsuk-tag">Work in progress</strong></span></h1>
+          <h1 class="nhsuk-heading-xl">Intranets <span style="vertical-align: middle;"><strong class="nhsuk-tag">In progress</strong></span></h1>
 
           <div class="nhsuk-inset-text">
             <span class="nhsuk-u-visually-hidden">Information: </span>
-            <p>We are working on this page. <br>The content will be released by August 29 2025.</p>
+        <p>We're working on intranet templates for NHS Wales. <br>We aim to publish these templates in August 2025.</p>
           </div>
 
-          <p>This page lists and describes different templates you can use to design intranets.</p>
+          <p>This page lists and describes different templates you can use to design intranets</p>
 
         </div>
 

--- a/app/views/terms-and-conditions.html
+++ b/app/views/terms-and-conditions.html
@@ -45,48 +45,43 @@
 
           <h1 class="nhsuk-heading-xl">Terms and conditions</h1>      
 
-          <p class="nhsuk-lede-text app-lede-text">This website is operated by NHS England. These terms govern your use of the NHS digital service manual.</p>
+          <p class="nhsuk-lede-text app-lede-text">This website is operated by Digital Health and Care Wales. These terms govern your use of the NHS Wales Design System.</p>
 
           <p>We may update these terms of use from time to time, and the revised version will be effective when displayed here.</p>
+         
+         <h2>Permitted use</h2> 
+          <p>Visitors to this site are granted permission to access published materials (content) subject to these terms. By using the website, you agree to be bound by the terms of use.</p>
+          <p>Content on the NHS Wales Design System website is available under the <a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/">Open Government License v3.0</a>.</P>
+          <p>Images, logos and graphics used on this site are owned by us and/or third parties. These must not be used without obtaining permission from the copyright owner.</p>
+          <p>You acknowledge that all intellectual property rights relating to this website belong to Digital Health and Care Wales and where applicable, third party associates.</p>
 
-          <p>You may access and use the NHS digital service manual if you agree to be legally bound by the terms set out here. If you do not agree to be legally bound by these terms please do not access or use the NHS digital service manual. If you break these terms and conditions your rights of use will end immediately.</p>
+          <h2>Personal information</h2>
+          
+          <p>When you voluntarily submit identifiable data on this website (this includes submission of feedback form, questionnaires etc.), the information submitted is used solely to respond to your queries and for its intended purpose. We do not share web user information with third parties.</p>
+         
+          <h2>Virus protection</h2>
+          
+          <p>We make every effort to check and test material for viruses. However, it is recommended that you run an anti-virus program on all materials downloaded from the internet. We cannot accept responsibility for any loss, disruption or damage to your data or computer system which may occur whilst using material derived from this website.</p>
+          
+          <h2>Disclaimer</h2>
+          
+          <p>Care is taken to ensure that the website content is accurate. Nevertheless, content is provided for general information only, and you use it at your own risk. We will not be held liable for damage or loss ensuing from any act or omission resulting from the use of information on this website.</p>
+          
+          <h2>External websites</h2>
+          
+          <p>Digital Health and Care Wales is not responsible for the content or reliability of any linked websites. We accept no liability in respect of the content or for the consequences of following any advice included on such sites.</</p>
 
-          <h2>Licence</h2>
+          <p>Listing should not be taken as an endorsement of any kind.</p>
 
-          <p>All content on the NHS digital service manual website is available under the <a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" style="color: #005eb8;">Open Government Licence v3.0</a>.</p>
+          <p>We cannot guarantee that these links will work all of the time and have no control over the availability of the linked pages or change of website address.</p>
 
-          <h2>Terms of use</h2>
-
-          <p>References to 'the NHS' mean 'the NHS in England' unless otherwise stated. Service descriptions, entitlements and costs refer to services in England and arrangements may differ elsewhere in the UK.</p>
-
-          <p>We cannot guarantee uninterrupted access to the website, or the sites to which it links. We accept no responsibility for any damage arising from the unavailability of this website or the information it contains.</p>
-
-          <p>This website contains links to other sites. We are not responsible for the content of any third party website and a link to another site does not mean NHS England endorses their site or content.</p>
-
-          <p>You may link to our website, provided you do so in a way that is fair and legal and does not damage our reputation or take advantage of it. You must not make a link in such a way as to suggest any form of association, approval or endorsement on our part. We reserve the right to withdraw linking permission without notice.</p>
-
-          <p>If you submit personal information to us through this website, it will be used in line with our <a href="/your-privacy" style="color: #005eb8;">privacy policy</a>.</p>
-
-          <p>We do not guarantee that this website will be secure or free from bugs or viruses. You are responsible for configuring your information technology, computer programmes and platform to access our site. You should use your own virus protection software.</p>
-
-          <p>You must not misuse this website by knowingly introducing viruses, trojans, worms, logic bombs or other material that is malicious or technologically harmful.</p>
-
-          <p>You must not attempt to gain unauthorised access to our site, the server on which this website is stored, or any server, computer or database connected to this website.
-          </p>
-
-          <p>You must not attack this website via a denial-of-service attack or a distributed denial-of-service attack.</p>
-
-          <p>By breaching this provision, you would commit a criminal offence under the Computer Misuse Act 1990. We will report any such breach to the relevant law enforcement authorities and we will co-operate with those authorities by disclosing your identity to them. In the event of such a breach, your right to use this website will end immediately.</p>
-
-          <h2>General</h2>
-
-          <p>These terms of use shall be governed by and interpreted in accordance with the laws of England, and we both agree to the exclusive jurisdiction of the courts of England in respect of any disputes which may arise in relation to our website.</p>
-
+          <p>Digital Health and Care Wales reserves the right to reject or remove links to any website.</p>
+          
           <h2>Contact details</h2>
 
           <p>Contact us by email at <a href="mailto:design-system@wales.nhs.uk" style="color: #005eb8;">design-system@wales.nhs.uk</a> if you have any questions.</p>
 
-          <p class="nhsuk-body-s nhsuk-u-secondary-text-color nhsuk-u-margin-top-6 nhsuk-u-margin-bottom-0">Updated: April 2023</p>
+          <p class="nhsuk-body-s nhsuk-u-secondary-text-color nhsuk-u-margin-top-6 nhsuk-u-margin-bottom-0">Updated: July 2025</p>
 
         </div>
 

--- a/app/views/your-privacy.html
+++ b/app/views/your-privacy.html
@@ -45,103 +45,51 @@
 
           <h1 class="nhsuk-heading-xl">Your privacy</h1>      
 
-          <p class="nhsuk-lede-text app-lede-text">Your privacy is important to us. This privacy policy covers what we collect and how we use, share and store your information.</p>
+          <p class="nhsuk-lede-text app-lede-text">Digital Health and Care Wales is a national organisation delivering technology and digital services for patient care in Wales. Our privacy policy explains what information we collect, what we do with it, your rights and how you can contact us if you need support.</p>
 
-          <p>This page tells you:</p>
+      
 
-          <ul>
-            <li>about the information we may collect</li>
-            <li>how we keep your data secure</li>
-            <li>who we share your data with</li>
-            <li>about your rights to see or change information we hold about you</li>
-          </ul>
+          <h2>Feedback and queries</h2>
+
+          <p><a href="https://dhcw.nhs.wales/use-of-site/feedback/">Contact us using our feedback form</a>. We will only use your contact details to respond to your query.</p>
 
           <h2>Information we may collect</h2>
-
-          <p>You can leave feedback on some pages of the website or on a user survey. You can choose to share your email address if you want a reply. Otherwise, we collect and store feedback anonymously</p>
-
+          
           <h3>Cookies</h3>
 
-          <p>Our website uses cookies. These are small files saved on your phone, tablet or computer when you visit a website. They store information about how you use the website, such as the pages you visit.</p>
+          <p>Cookies are pieces of data created when you visit a website. Our site uses cookies to store information while you move around the site. You can set your computer not to accept cookies. However, if you do this, you may not be able to use some site features because we need to record your preferences in order to give you the information you need during your visit.</p>
+          
+          <p>Our cookies do not contain any personal information about you and do not hold any information about which sites you visited before you came here.</p>
 
-          <p>The law says that we can store cookies on your device if they are strictly necessary to make our website work. For all other types of cookies we need your permission before we can use them on your device.</p>
+          <p><a href="/cookie-policy">Read our cookie policy</a> to find out more about the cookies we use.</p>
 
-          <p>We like to use analytics cookies which measure how you use our website and help us improve our service for future users but we only use these cookies if you say it's OK.</p>
+        
+          <h3>Personal information</h3>
 
-          <p>
-            <a href="/cookie-policy" style="color: #005eb8;">Read our cookie policy</a> to find out more about the cookies we use and tell us if we can put analytics cookies on your device.
-          </p>
+          <p>We do not collect personal information about site users.</p>
 
-          <p>We sometimes use tools on other organisations' websites to collect data or to ask for feedback. These tools set their own cookies. </p>
+          <p>When you voluntarily submit identifiable data on this website (this includes submission of feedback forms or questionnaires), the information submitted is used solely to respond to your queries and for its intended purpose.</p>
 
-          <h3>Social media</h3>
+          <h3>Google Analytics</h3>
 
-          <p>We use the following social media platforms to interact with our users:</p>
+          <p>This website uses <a href="https://marketingplatform.google.com/about/analytics/">Google Analytics</a>, a web analytics service provided by Google Inc. ('Google'). Google Analytics uses 'cookies' and JavaScript code to help analyse user activity on websites. The information generated about your use of the website (including your IP address) will be transmitted to and stored on Google servers in the United States.</p>
+         
+          <p>Google will use this information to produce user activity reports for this website. Google may also transfer this information to third parties where required to do so by law, or where such third parties process the information on Google's behalf.</p>
 
-          <ul>
-            <li>Twitter</li>
-            <li>YouTube</li>
-          </ul>
+          <p>Google will not associate your IP address with any other data previously held. You may refuse the use of cookies by selecting the appropriate settings on your browser. Please note that if cookies are disabled, you may not be able to use the full functionality of this website. By using this website, you consent to the processing of data about you by Google in the manner and for the purposes set out above.</p>
 
-          <h4>How we collect and store your data</h4>
+          <p>Read <a href="https://policies.google.com/privacy">Google's Full Privacy Policy</a> and <a href="https://marketingplatform.google.com/about/analytics/terms/us/">Terms of Service</a> for detailed information.</p>
 
-          <p>If you interact with us on social media, we may receive some personally identifiable data about you, which is supplied by the channel you are using (for example, Twitter or YouTube). This may include:</p>
+          <h3>Why we collect user statistics</h3>
 
-          <ul>
-            <li>your name</li>
-            <li>social media handles (such as Twitter account name)</li>
-            <li>location history (where you are contacting us from)</li>
-            <li>images (such as your profile picture)</li>
-          </ul>
+          <p>By understanding user behaviour and preferences, we are able to improve our website content to meet user expectations and needs.</p>
 
-          <p>We will process and store your data in accordance with the terms and conditions and privacy policy of the platform in question. You should be aware that your use of these platforms is governed by the terms and conditions agreed between you and the platform, rather than with us.</p>
+          <h3>Links to external sites</h3>
+          
+          <p>Like most sites, the NHS Design System website contains links to external sites. It should be noted that this privacy policy can apply only to this site and that we cannot be responsible for the privacy practices of other websites.</p>
 
-          <p>We will not remove, duplicate or transfer your personal data from or between any of the social platforms that we use, except for when you give us explicit permission to do so or when we believe that we need to in order to respond to an urgent risk to health.</p>
-
-          <p>For example, if you interact with us in a way that raises serious concerns about your mental health, we may share your personal details with local NHS services to make sure that you are offered appropriate support.</p>
-
-          <p>You should be aware that social networks may control some of the data associated with interactions between you (the user) and us (the NHS digital service manual) on their platforms. For example, we will be able to delete our own records of a private message conversation if you ask us to do so, but social networks may store a copy of this conversation that we are unable to access.</p>
-
-          <p>We recommend using the privacy tools built into the social networks in question to make sure you are able to exercise your rights appropriately.</p>
-
-          <h4>Understanding how social networks use your data</h4>
-
-          <p>Social networks use information about your online activity to build a profile of you. This data is then used (anonymously) to send you targeted adverts across various digital platforms.</p>
-
-          <p>You should be aware that interacting with accounts such as ours may help build the profile of you that social networks maintain, and that could potentially result in you receiving adverts about related issues.</p>
-
-          <p>This process of collecting data for advertising purposes is not controlled by the NHS digital service manual, and we do not have access to the profiling data stored by social networks about you.</p>
-
-          <h2>Keeping your personal data secure</h2>
-
-          <p>We convert your data into secure code (encrypt it) and store it on secure servers in England. A partner organisation is providing hosting services but has no say in how the information is used. There are no legal ways for their employees to see the data. Only approved people in the NHS digital service manual team can see it.</p>
-
-          <p>If you shared your email with us as part of a survey, we will delete it after 2 years. At that point no one can identify you in the survey data.</p>
-
-          <h2>Data sharing</h2>
-
-          <p>NHS England may share anonymous information on how the service is used with the Department of Health and Social Care, integrated care boards (ICBs), and national governance groups.</p>
-
-          <h3>Legal powers</h3>
-
-          <p>When you give us personal information, we may pass it on if the law says we must.</p>
-
-          <p>If you make a claim against us, we and other third parties such as our solicitors may need to look at this information.</p>
-
-          <p>We will not share your personal information with anyone else without your permission for any other reason.</p>
-
-          <h2>Your rights</h2>
-
-          <p>You can:</p>
-
-          <ul>
-            <li>find out what information we hold about you, ask us to correct it if it's wrong, or delete it by emailing <a href="mailto:design-system@wales.nhs.uk" style="color: #005eb8;">design-system@wales.nhs.uk</a></li>
-            <li>contact the <a href="https://ico.org.uk/" style="color: #005eb8;">Information Commissioner's Office</a>, Wycliffe House Water Lane, Wilmslow SK9 5AF if you want to make a complaint about how we have managed your data</li>
-          </ul>
-
-          <p>NHS Digital (NHS England), 1 Trevelyan Square, Boar Lane, Leeds, LS1 6AE is the Data Controller for the NHS digital service manual under data protection legislation. We will process your data in line with data protection legislation.</p>
-
-          <p class="nhsuk-body-s nhsuk-u-secondary-text-color nhsuk-u-margin-top-6 nhsuk-u-margin-bottom-0">Updated: April 2023</p>
+          <p>We do not pass on any personal information you have given us to any other website. We do not pass on any personal information you have given us to any other website.</p>
+         
 
         </div>
 


### PR DESCRIPTION
Final round of content updates to ensure that we can accurately demo the design system to an NHS Wales audience. Alignment of content with DHCW best practice and existing content standards.

## Description
Replacement or adaptation of NHS England's content with existing NHS Wales website content. Changes made to:
- Index
- Patterns services
- Patterns tasks
- Patterns pages
- Components body
- Templates applications
- Templates intranets
- Templates extranets
- Design system team
 - Get in touch
 - Cookie policy
 - Terms and conditions
 - Your privacy
 
Accessibility statement content unchanged - the NHS Wales standard specifically relates to websites created with Mura and the UI/UX/design associated with that (this is separate to that work). This will be monitored and revised in future design system iterations. A round of accessibility testing will be needed.

## Motivation and Context
The deadline for this work is imminent. These updates ensure that content is compliant, clear, accurate and relevant for an NHS Wales audience.