### PR TITLE
Minor content revisions

### DIFF
--- a/app/views/components-body.html
+++ b/app/views/components-body.html
@@ -38,7 +38,7 @@
 
           <div class="nhsuk-inset-text">
             <span class="nhsuk-u-visually-hidden">Information: </span>
-            <p>We're working on body components for NHS Wales. <br>We aim to publish these components in August 2025.</p>
+            <p>We're developing these components. We aim to publish them in autumn 2025.</p>
           </div>
 
           <p>This page lists and describes different body components you can use to design digital services.</p>

--- a/app/views/design-system-team.html
+++ b/app/views/design-system-team.html
@@ -45,7 +45,7 @@
 
           <h1 class="nhsuk-heading-xl">Design system team</h1>      
 
-          <p class="nhsuk-lede-text app-lede-text">The user-centred design team at Digital Health and Care Wales maintains the NHS Wales design system.</p>
+          <p class="nhsuk-lede-text app-lede-text">The design system team at Digital Health and Care Wales maintains the NHS Wales design system.</p>
           <p>We work with colleagues across NHS Wales to research and develop components, patterns and templates based on evidence.</p>
 
           <p>If you want to contact the team, you can <a href="/get-in-touch" style="color: #005eb8;">get in touch via email</a>.</p>

--- a/app/views/get-in-touch.html
+++ b/app/views/get-in-touch.html
@@ -45,7 +45,7 @@
 
           <h1 class="nhsuk-heading-xl">Get in touch</h1>      
 
-          <p class="nhsuk-lede-text app-lede-text">If you’ve got a question, idea or suggestion, get in touch with the user-centred design team.</p>
+          <p class="nhsuk-lede-text app-lede-text">If you’ve got a question, idea or suggestion, get in touch with the design system team.</p>
 
           <p>Email the team on <a href="mailto:design-system@wales.nhs.uk" style="color: #005eb8;">design-system@wales.nhs.uk</a>.</p>
 

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -14,7 +14,7 @@
           <div class="nhsuk-grid-column-two-thirds">
             <div class="nhsuk-hero__wrapper app-hero__wrapper" style="padding-top: 40px;">
               <h1 class="nhsuk-u-margin-bottom-4">Design and build accessible digital services for NHS Wales</h1>
-              <p class="nhsuk-body-l nhsuk-u-margin-bottom-1">The NHS Wales Design System follows the NHS service manual with additional components, patterns, styles and templates developed by Digital Health and Care Wales.</p>
+              <p class="nhsuk-body-l nhsuk-u-margin-bottom-1">This design system follows the NHS service manual with additional components, patterns, styles and templates developed by Digital Health and Care Wales.</p>
             </div>
           </div>
           <!-- WHAT'S NEW
@@ -53,9 +53,9 @@
           <li class="nhsuk-grid-column-full nhsuk-card-group__item" style="padding-left: 0px;padding-right: 0px;">
             <div class="nhsuk-card" style="background-color: #ffffff;height: 440px;">
               <div class="nhsuk-card__content" style="padding-bottom: 0px;">
-                <h3 class="nhsuk-card__heading" style="font-size: 19px; margin-bottom: 5px;">Clinical System UI Standards</h3>
+                <h3 class="nhsuk-card__heading" style="font-size: 19px; margin-bottom: 5px;">Clinical UI standards</h3>
                 <p class="nhsuk-card__description">
-                  <a href="https://nhswales365.sharepoint.com/sites/DHC_UIStandards/Shared%20Documents/Forms/AllItems.aspx?csf=1&web=1&e=SAOVHo&OR=Teams-HL&CT=1752247601684&CID=56c4b0a1-905c-d000-3cae-9292fdb1247c&cidOR=SPO&FolderCTID=0x012000A2E3CE482B02D640970E97C359F11248&id=%2fsites%2fDHC_UIStandards%2fShared+Documents%2fGeneral" target="blank" style="color: #005eb8;">View documents</a> 
+                  <a href="https://nhswales365.sharepoint.com/sites/DHC_UIStandards/Shared%20Documents/Forms/AllItems.aspx?csf=1&web=1&e=SAOVHo&OR=Teams-HL&CT=1752247601684&CID=56c4b0a1-905c-d000-3cae-9292fdb1247c&cidOR=SPO&FolderCTID=0x012000A2E3CE482B02D640970E97C359F11248&id=%2fsites%2fDHC_UIStandards%2fShared+Documents%2fGeneral" target="blank" style="color: #005eb8;">View documents</a> (opens in new window) 
                 </p>
               </div>
               <div class="nhsuk-card__content" style="padding-bottom: 0px;">

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -156,7 +156,7 @@
           <div class="nhsuk-grid-column-full">
             <hr class="nhsuk-u-margin-top-2 nhsuk-u-margin-bottom-6">
             <h2>Support</h2>
-            <p style="padding-bottom: 20px;">The manual is maintained by the <a href="design-system-team" style="color: #005eb8;">user-centred design team at Digital Health and Care Wales</a>. <br>If you've got a question or want to give feedback, you can <a href="get-in-touch" style="color: #005eb8;">get in touch</a>.</p>
+            <p style="padding-bottom: 20px;">The manual is maintained by the <a href="design-system-team" style="color: #005eb8;">design system team at Digital Health and Care Wales</a>. <br>If you've got a question or want to give feedback, you can <a href="get-in-touch" style="color: #005eb8;">get in touch</a>.</p>
           </div>
         </div>
 

--- a/app/views/patterns-pages.html
+++ b/app/views/patterns-pages.html
@@ -38,7 +38,7 @@
 
           <div class="nhsuk-inset-text">
             <span class="nhsuk-u-visually-hidden">Information: </span>
-           <p>We're working on page patterns for NHS Wales. <br>We aim to publish these patterns in August 2025.</p>
+            <p>We're developing new patterns. We aim to publish them in autumn 2025.</p>
           </div>
 
           <p>This page lists and describes different page patterns you can use to design digital services.</p>

--- a/app/views/patterns-services.html
+++ b/app/views/patterns-services.html
@@ -38,7 +38,7 @@
 
           <div class="nhsuk-inset-text">
             <span class="nhsuk-u-visually-hidden">Information: </span>
-            <p>We're working on service patterns for NHS Wales. <br>We aim to publish these patterns in August 2025.</p>
+            <p>We're developing new patterns. We aim to publish them in autumn 2025.</p>
           </div>
 
           <p>This page lists and describes different service patterns you can use to design digital services.</p>

--- a/app/views/patterns-tasks.html
+++ b/app/views/patterns-tasks.html
@@ -38,7 +38,7 @@
 
           <div class="nhsuk-inset-text">
             <span class="nhsuk-u-visually-hidden">Information: </span>
-            <p>We're working on task patterns for NHS Wales. <br>We aim to publish these patterns in August 2025.</p>
+            <p>We're developing new patterns. We aim to publish them in autumn 2025.</p>
           </div>
 
           <p>This page lists and describes different task patterns you can use to design digital services.</p>

--- a/app/views/templates-applications.html
+++ b/app/views/templates-applications.html
@@ -38,7 +38,7 @@
 
           <div class="nhsuk-inset-text">
             <span class="nhsuk-u-visually-hidden">Information: </span>
-             <p>We're working on application templates for NHS Wales. <br>We aim to publish these templates in August 2025.</p>
+            <p>We're developing new templates. We aim to publish them in autumn 2025.</p>
           </div>
 
           <p>This page lists and describes different templates you can use to design applications.</p>

--- a/app/views/templates-extranets.html
+++ b/app/views/templates-extranets.html
@@ -38,7 +38,7 @@
 
           <div class="nhsuk-inset-text">
             <span class="nhsuk-u-visually-hidden">Information: </span>
-             <p>We're working on extranet templates for NHS Wales. <br>We aim to publish these templates in August 2025.</p>
+            <p>We're developing new templates. We aim to publish them in autumn 2025.</p>
           </div>
 
           <p>This page lists and describes different templates you can use to design extranets.</p>

--- a/app/views/templates-intranets.html
+++ b/app/views/templates-intranets.html
@@ -38,7 +38,7 @@
 
           <div class="nhsuk-inset-text">
             <span class="nhsuk-u-visually-hidden">Information: </span>
-        <p>We're working on intranet templates for NHS Wales. <br>We aim to publish these templates in August 2025.</p>
+            <p>We're developing new templates. We aim to publish them in autumn 2025.</p>
           </div>
 
           <p>This page lists and describes different templates you can use to design intranets</p>


### PR DESCRIPTION
Small updates to several pages including:
- index
- design system team
- get in touch
- components body
- all patterns pages
- most templates pages

## Description
Minor content revisions:
- removal of reference to 'NHS Wales Design System as a temporary measure.
- updates instances of 'user-centred design team' to 'design system team'
- update to holding text for unfinished components/patterns/templates with a longer lead time and more concise text
