### PR TITLE
Content changes to pages still in development

### DIFF
--- a/app/views/components-body.html
+++ b/app/views/components-body.html
@@ -38,7 +38,7 @@
 
           <div class="nhsuk-inset-text">
             <span class="nhsuk-u-visually-hidden">Information: </span>
-            <p>We're developing these components. We aim to publish them in autumn 2025.</p>
+            <p>We're developing these components. If you have a feedback or a request, email the design manual team on <a href="mailto:design-system@wales.nhs.uk" style="color: #005eb8;">design-system@wales.nhs.uk</a></p>
           </div>
 
           <p>This page lists and describes different body components you can use to design digital services.</p>

--- a/app/views/components-body.html
+++ b/app/views/components-body.html
@@ -38,7 +38,7 @@
 
           <div class="nhsuk-inset-text">
             <span class="nhsuk-u-visually-hidden">Information: </span>
-            <p>We're developing these components. If you have a feedback or a request, email the design manual team on <a href="mailto:design-system@wales.nhs.uk" style="color: #005eb8;">design-system@wales.nhs.uk</a></p>
+            <p>We're developing these components. If you have feedback or a request, email the design manual team at <a href="mailto:design-system@wales.nhs.uk" style="color: #005eb8;">design-system@wales.nhs.uk</a></p>
           </div>
 
           <p>This page lists and describes different body components you can use to design digital services.</p>

--- a/app/views/patterns-pages.html
+++ b/app/views/patterns-pages.html
@@ -38,7 +38,7 @@
 
           <div class="nhsuk-inset-text">
             <span class="nhsuk-u-visually-hidden">Information: </span>
-            <p>We're developing new patterns. We aim to publish them in autumn 2025.</p>
+            <p>We're developing these patterns. If you have feedback or a request, email the design manual team at <a href="mailto:design-system@wales.nhs.uk" style="color: #005eb8;">design-system@wales.nhs.uk</a></p>
           </div>
 
           <p>This page lists and describes different page patterns you can use to design digital services.</p>

--- a/app/views/patterns-services.html
+++ b/app/views/patterns-services.html
@@ -38,7 +38,7 @@
 
           <div class="nhsuk-inset-text">
             <span class="nhsuk-u-visually-hidden">Information: </span>
-            <p>We're developing new patterns. We aim to publish them in autumn 2025.</p>
+            <p>We're developing these patterns. If you have feedback or a request, email the design manual team at <a href="mailto:design-system@wales.nhs.uk" style="color: #005eb8;">design-system@wales.nhs.uk</a></p>
           </div>
 
           <p>This page lists and describes different service patterns you can use to design digital services.</p>

--- a/app/views/patterns-tasks.html
+++ b/app/views/patterns-tasks.html
@@ -38,7 +38,7 @@
 
           <div class="nhsuk-inset-text">
             <span class="nhsuk-u-visually-hidden">Information: </span>
-            <p>We're developing new patterns. We aim to publish them in autumn 2025.</p>
+            <p>We're developing these patterns. If you have feedback or a request, email the design manual team at <a href="mailto:design-system@wales.nhs.uk" style="color: #005eb8;">design-system@wales.nhs.uk</a></p>
           </div>
 
           <p>This page lists and describes different task patterns you can use to design digital services.</p>

--- a/app/views/templates-applications.html
+++ b/app/views/templates-applications.html
@@ -38,7 +38,7 @@
 
           <div class="nhsuk-inset-text">
             <span class="nhsuk-u-visually-hidden">Information: </span>
-            <p>We're developing new templates. We aim to publish them in autumn 2025.</p>
+            <p>We're developing these templates. If you have feedback or a request, email the design manual team at <a href="mailto:design-system@wales.nhs.uk" style="color: #005eb8;">design-system@wales.nhs.uk</a></p>
           </div>
 
           <p>This page lists and describes different templates you can use to design applications.</p>

--- a/app/views/templates-extranets.html
+++ b/app/views/templates-extranets.html
@@ -38,7 +38,7 @@
 
           <div class="nhsuk-inset-text">
             <span class="nhsuk-u-visually-hidden">Information: </span>
-            <p>We're developing new templates. We aim to publish them in autumn 2025.</p>
+            <p>We're developing these templates. If you have feedback or a request, email the design manual team at <a href="mailto:design-system@wales.nhs.uk" style="color: #005eb8;">design-system@wales.nhs.uk</a></p>
           </div>
 
           <p>This page lists and describes different templates you can use to design extranets.</p>

--- a/app/views/templates-intranets.html
+++ b/app/views/templates-intranets.html
@@ -38,7 +38,7 @@
 
           <div class="nhsuk-inset-text">
             <span class="nhsuk-u-visually-hidden">Information: </span>
-            <p>We're developing new templates. We aim to publish them in autumn 2025.</p>
+            <p>We're developing these templates. If you have feedback or a request, email the design manual team at <a href="mailto:design-system@wales.nhs.uk" style="color: #005eb8;">design-system@wales.nhs.uk</a></p>
           </div>
 
           <p>This page lists and describes different templates you can use to design intranets</p>


### PR DESCRIPTION
Changed the holder text for the components, patterns and templates pages that don't yet have any content. Inclusion of the email address for people to make suggestions to add to our backlog.
